### PR TITLE
refactor(vats): Implement vtransfer app intercept in the bridge registry rather than in middleware

### DIFF
--- a/packages/boot/test/bootstrapTests/vtransfer.test.ts
+++ b/packages/boot/test/bootstrapTests/vtransfer.test.ts
@@ -4,10 +4,8 @@ import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import type { TestFn } from 'ava';
 
 import type { ScopedBridgeManager } from '@agoric/vats';
-import type {
-  TransferMiddleware,
-  TransferVat,
-} from '@agoric/vats/src/vat-transfer.js';
+import type { TransferMiddleware } from '@agoric/vats/src/transfer.js';
+import type { TransferVat } from '@agoric/vats/src/vat-transfer.js';
 import { BridgeId, VTRANSFER_IBC_EVENT } from '@agoric/internal';
 import { makeSwingsetTestKit } from '../../tools/supports.ts';
 

--- a/packages/orchestration/test/supports.ts
+++ b/packages/orchestration/test/supports.ts
@@ -51,13 +51,19 @@ export const commonSetup = async t => {
   );
 
   const transferBridge = makeFakeTransferBridge(rootZone);
-  const { makeTransferMiddleware, makeBridgeTargetKit } = prepareTransferTools(
-    rootZone.subZone('transfer'),
-    prepareVowTools(rootZone.subZone('vows')),
+  const { makeTransferMiddlewareKit, makeBridgeTargetKit } =
+    prepareTransferTools(
+      rootZone.subZone('transfer'),
+      prepareVowTools(rootZone.subZone('vows')),
+    );
+  const { finisher, interceptorFactory, transferMiddleware } =
+    makeTransferMiddlewareKit();
+  const bridgeTargetKit = makeBridgeTargetKit(
+    transferBridge,
+    VTRANSFER_IBC_EVENT,
+    interceptorFactory,
   );
-  const transferMiddleware = makeTransferMiddleware(
-    makeBridgeTargetKit(transferBridge, VTRANSFER_IBC_EVENT),
-  );
+  finisher.useRegistry(bridgeTargetKit.targetRegistry);
 
   const localchainBridge = makeFakeLocalchainBridge(rootZone);
   const localchain = prepareLocalChainTools(

--- a/packages/vats/src/proposals/vtransfer-echoer.js
+++ b/packages/vats/src/proposals/vtransfer-echoer.js
@@ -5,7 +5,7 @@ import { E } from '@endo/far';
 /**
  * @param {BootstrapPowers & {
  *   consume: {
- *     transferMiddleware: import('../vat-transfer.js').TransferMiddleware;
+ *     transferMiddleware: import('../transfer.js').TransferMiddleware;
  *   };
  * }} powers
  * @param {object} options

--- a/packages/vats/src/transfer.js
+++ b/packages/vats/src/transfer.js
@@ -214,7 +214,7 @@ const prepareTransferMiddlewareKit = (zone, makeTransferInterceptor) =>
         /**
          * Register a tap to intercept the vtransfer target account address
          * messages, without granting that tap the ability to delay or interfere
-         * with the underlying IBC transfer protocol.ß
+         * with the underlying IBC transfer protocol.
          *
          * @type {RegisterTap}
          */
@@ -225,7 +225,7 @@ const prepareTransferMiddlewareKit = (zone, makeTransferInterceptor) =>
         },
         /**
          * Similar to `registerTap`, but allows the tap to inject async
-         * ßacknowledgements in the IBC transfer protocol.
+         * acknowledgements in the IBC transfer protocol.
          *
          * @type {RegisterTap}
          */

--- a/packages/vats/src/vat-transfer.js
+++ b/packages/vats/src/vat-transfer.js
@@ -16,7 +16,7 @@ export const buildRootObject = (_vatPowers, _args, baggage) => {
 
   const vowTools = prepareVowTools(zone.subZone('vow'));
 
-  const { makeTransferMiddleware } = prepareTransferTools(
+  const { makeTransferMiddlewareKit } = prepareTransferTools(
     zone.subZone('transfer'),
     vowTools,
   );
@@ -36,24 +36,28 @@ export const buildRootObject = (_vatPowers, _args, baggage) => {
      * @template {import('@agoric/internal').BridgeIdValue} T
      * @param {import('./types').ScopedBridgeManager<T>} manager
      * @param {string} [inboundType]
+     * @param {import('./bridge-target').AppTransformer} [appTransformer]
      */
-    provideBridgeTargetKit(manager, inboundType = 'IBC_EVENT') {
+    provideBridgeTargetKit(
+      manager,
+      inboundType = 'IBC_EVENT',
+      appTransformer = undefined,
+    ) {
       /** @type {MapStore<string, ReturnType<typeof makeBridgeTargetKit>>} */
       const inboundTypeToKit = provideLazy(managerToKits, manager, () =>
         zone.detached().mapStore('inboundTypeToKit'),
       );
       const kit = provideLazy(inboundTypeToKit, inboundType, () =>
-        makeBridgeTargetKit(manager, inboundType),
+        makeBridgeTargetKit(manager, inboundType, appTransformer),
       );
       return kit;
     },
     /**
-     * Create a middleware for exposing IBC messages to and from the underlying
+     * Create middleware for exposing IBC messages to and from the underlying
      * vtransfer port as data with embedded `action` ocaps where safe.
      */
-    makeTransferMiddleware,
+    makeTransferMiddlewareKit,
   });
 };
 
 /** @typedef {ReturnType<typeof buildRootObject>} TransferVat */
-/** @typedef {ReturnType<TransferVat['makeTransferMiddleware']>} TransferMiddleware */

--- a/packages/vats/test/localchain.test.js
+++ b/packages/vats/test/localchain.test.js
@@ -50,9 +50,14 @@ const makeTestContext = async _t => {
     transferZone,
     prepareVowTools(transferZone.subZone('vows')),
   );
-  const transferMiddleware = transferTools.makeTransferMiddleware(
-    transferTools.makeBridgeTargetKit(transferBridge, VTRANSFER_IBC_EVENT),
+  const { finisher, interceptorFactory, transferMiddleware } =
+    transferTools.makeTransferMiddlewareKit();
+  const bridgeTargetKit = transferTools.makeBridgeTargetKit(
+    transferBridge,
+    VTRANSFER_IBC_EVENT,
+    interceptorFactory,
   );
+  finisher.useRegistry(bridgeTargetKit.targetRegistry);
 
   const { bankManager, pourPayment } = await makeFakeBankManagerKit({
     balances: {


### PR DESCRIPTION
This prevents the authority leak described at https://github.com/Agoric/agoric-sdk/pull/8624#discussion_r1628573604 .